### PR TITLE
Change online reading link to kehuan.fun

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # 科幻小说作品集
 > 自己收集的科幻小说作品集
 > 
-> 在线阅读：https://github-novel-read.vercel.app
+> 在线阅读：https://kehuan.fun
 >
 > 本readme文件由仓库内script.py脚本自动生成。
 ## 目前作家


### PR DESCRIPTION
Updated online reading link in README.md.

域名更换，支持国内用户直接查看，vercel 域名直接重定向到最新域名 https://kehuan.fun